### PR TITLE
Use category as first argument and do not detect (co)limits automatically

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -19,8 +19,8 @@ jobs:
     container:
       image: ${{ matrix.image }}
     steps:
-      # keep workflow active even if repository has no activity for 60 days
-      - run: 'curl --fail -X PUT -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows/Tests.yml/enable'
+      # keep workflow active even if repository has no activity for 60 days (do not execute for pull requests)
+      - run: '[ "$GITHUB_EVENT_NAME" = "pull_request" ] || curl --fail -X PUT -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows/Tests.yml/enable'
       - uses: actions/checkout@v1
       - run: mkdir -p /home/gap/.gap/pkg/
       - run: sudo cp -a $GITHUB_WORKSPACE /home/gap/.gap/pkg/

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -16,7 +16,7 @@ Version := Maximum( [
                    ## this line prevents merge conflicts
                    "2019.03-17", ## Tom's version
                    ## this line prevents merge conflicts
-                   "2021.05-01", ## Fabian's version
+                   "2021.06-01", ## Fabian's version
                    ] ),
 
 Date := ~.Version{[ 1 .. 10 ]},
@@ -111,7 +111,7 @@ Dependencies := rec(
                    [ "GAPDoc", ">= 1.5" ],
                    [ "ToolsForHomalg", ">= 2020.09.06" ],
                    [ "CAP", ">= 2021.05-02" ],
-                   [ "CategoryConstructor", ">= 2020.10-02" ],
+                   [ "CategoryConstructor", ">= 2021.06-01" ],
                    [ "MonoidalCategories", ">= 2020.03.01" ],
                    [ "Toposes", ">= 2020.06.05" ],
                    [ "Digraphs", ">= 0.12.1" ],

--- a/gap/BooleanAlgebra.gi
+++ b/gap/BooleanAlgebra.gi
@@ -8,14 +8,14 @@ InstallValue( BOOLEAN_ALGEBRA_METHOD_NAME_RECORD,
         rec(
 MorphismFromDoubleNegationWithGivenDoubleNegation := rec(
   installation_name := "MorphismFromDoubleNegationWithGivenDoubleNegation",
-  filter_list := [ "object", "object" ],
+  filter_list := [ "category", "object", "object" ],
   io_type := [ [ "a", "s" ], [ "s", "a" ] ],
   cache_name := "MorphismFromDoubleNegationWithGivenDoubleNegation",
   return_type := "morphism" ),
             
 MorphismToDoubleConegationWithGivenDoubleConegation := rec(
   installation_name := "MorphismToDoubleConegationWithGivenDoubleConegation",
-  filter_list := [ "object", "object" ],
+  filter_list := [ "category", "object", "object" ],
   io_type := [ [ "a", "s" ], [ "s", "a" ] ],
   cache_name := "MorphismToDoubleConegationWithGivenDoubleConegation",
   return_type := "morphism" ),

--- a/gap/BooleanAlgebra.gi
+++ b/gap/BooleanAlgebra.gi
@@ -40,7 +40,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_BOOLEAN_ALGEBRAS,
     
     ##
     AddMorphismFromDoubleNegationWithGivenDoubleNegation( boolean_algebra,
-      function( A, B )
+      function( cat, A, B )
         
         return UniqueMorphism( B, A );
         
@@ -48,7 +48,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_BOOLEAN_ALGEBRAS,
     
     ##
     AddMorphismToDoubleConegationWithGivenDoubleConegation( boolean_algebra,
-      function( A, B )
+      function( cat, A, B )
         
         return UniqueMorphism( A, B );
         

--- a/gap/CoHeytingAlgebra.gi
+++ b/gap/CoHeytingAlgebra.gi
@@ -69,7 +69,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_COHEYTING_ALGEBRAS,
     
     ##
     AddCoexponentialOnMorphismsWithGivenCoexponentials( coheyting_algebra,
-      function( S, alpha, beta, R )
+      function( cat, S, alpha, beta, R )
         
         return UniqueMorphism( S, R );
         
@@ -77,7 +77,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_COHEYTING_ALGEBRAS,
     
     ##
     AddCocartesianEvaluationMorphismWithGivenRange( coheyting_algebra,
-      function( A, B, BxCoex_A_B )
+      function( cat, A, B, BxCoex_A_B )
         
         return UniqueMorphism( A, BxCoex_A_B );
         
@@ -85,7 +85,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_COHEYTING_ALGEBRAS,
     
     ##
     AddCocartesianCoevaluationMorphismWithGivenSource( coheyting_algebra,
-      function( A, B, Coex_AxB_A)
+      function( cat, A, B, Coex_AxB_A)
         
         return UniqueMorphism( Coex_AxB_A, B );
         
@@ -93,7 +93,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_COHEYTING_ALGEBRAS,
     
     ##
     AddCoproductToCoexponentialAdjunctionMap( coheyting_algebra,
-      function( B, C, g )
+      function( cat, B, C, g )
         local A;
         
         A := Source( g );
@@ -104,7 +104,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_COHEYTING_ALGEBRAS,
     
     ##
     AddCoexponentialToCoproductAdjunctionMap( coheyting_algebra,
-      function( A, B, f )
+      function( cat, A, B, f )
         local C, BC;
         
         C := Range( f );
@@ -117,7 +117,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_COHEYTING_ALGEBRAS,
     
     ##
     AddCocartesianPreCoComposeMorphismWithGivenObjects( coheyting_algebra,
-      function( Coex_A_C, A, B, C, Coex_A_BxCoex_B_C);
+      function( cat, Coex_A_C, A, B, C, Coex_A_BxCoex_B_C);
         
         return UniqueMorphism( Coex_A_C, Coex_A_BxCoex_B_C );
         
@@ -125,7 +125,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_COHEYTING_ALGEBRAS,
     
     ##
     AddCocartesianPostCoComposeMorphismWithGivenObjects( coheyting_algebra,
-      function( Coex_A_C, A, B, C, Coex_B_CxCoex_A_B );
+      function( cat, Coex_A_C, A, B, C, Coex_B_CxCoex_A_B );
         
         return UniqueMorphism( Coex_A_C, Coex_B_CxCoex_A_B );
         
@@ -133,7 +133,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_COHEYTING_ALGEBRAS,
     
     ##
     AddCoexponentialCoproductCompatibilityMorphismWithGivenObjects( coheyting_algebra,
-      function( A1, A2, B1, B2, L )
+      function( cat, A1, A2, B1, B2, L )
         
         return UniqueMorphism( L[1], L[2] );
         
@@ -143,7 +143,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_COHEYTING_ALGEBRAS,
     
     ##
     AddMorphismFromDoubleConegationWithGivenDoubleConegation( coheyting_algebra,
-      function( A, B )
+      function( cat, A, B )
         
         return UniqueMorphism( A, B );
         

--- a/gap/CoHeytingAlgebra.gi
+++ b/gap/CoHeytingAlgebra.gi
@@ -8,7 +8,7 @@ InstallValue( COHEYTING_ALGEBRA_METHOD_NAME_RECORD,
         rec(
 ConegationOnObjects := rec(
   installation_name := "ConegationOnObjects",
-  filter_list := [ "object" ],
+  filter_list := [ "category", "object" ],
   io_type := [ [ "a" ], [ "an" ] ],
   cache_name := "ConegationOnObjects",
   return_type := "object" ),
@@ -16,13 +16,13 @@ ConegationOnObjects := rec(
 ConegationOnMorphismsWithGivenConegations := rec(
   installation_name := "ConegationOnMorphismsWithGivenConegations",
   io_type := [ [ "s", "alpha", "r" ], [ "s", "r" ] ],
-  filter_list := [ "object", "morphism", "object" ],
+  filter_list := [ "category", "object", "morphism", "object" ],
   cache_name := "ConegationOnMorphismsWithGivenConegations",
   return_type := "morphism" ),
 
 MorphismFromDoubleConegationWithGivenDoubleConegation := rec(
   installation_name := "MorphismFromDoubleConegationWithGivenDoubleConegation",
-  filter_list := [ "object", "object" ],
+  filter_list := [ "category", "object", "object" ],
   io_type := [ [ "a", "r" ], [ "a", "r" ] ],
   cache_name := "MorphismFromDoubleConegationWithGivenDoubleConegation",
   return_type := "morphism" )
@@ -158,7 +158,7 @@ AddDerivationToCAP( IsHomSetInhabited,
         
   function( cat, S, T )
     
-    return IsInitial( CoexponentialOnObjects( S, T ) );
+    return IsInitial( cat, CoexponentialOnObjects( cat, S, T ) );
     
 end : Description := "IsHomSetInhabited using IsInitial and CoexponentialOnObjects",
       CategoryFilter := IsThinCategory and IsCocartesianCoclosedCategory );
@@ -168,9 +168,9 @@ AddDerivationToCAP( ConegationOnObjects,
         [ [ CoexponentialOnObjects, 1 ],
           [ TerminalObject, 1 ] ],
         
-  function( A )
+  function( cat, A )
     
-    return CoexponentialOnObjects( TerminalObject( CapCategory( A ) ), A );
+    return CoexponentialOnObjects( cat, TerminalObject( cat ), A );
     
 end : Description := "ConegationOnObjects using CoexponentialOnObjects and TerminalObject",
       CategoryFilter := IsThinCategory and IsCocartesianCoclosedCategory );
@@ -181,9 +181,9 @@ AddDerivationToCAP( ConegationOnMorphismsWithGivenConegations,
           [ IdentityMorphism, 1 ],
           [ TerminalObject, 1 ] ],
         
-  function( B_, u, A_ )
+  function( cat, B_, u, A_ )
     
-    return CoexponentialOnMorphismsWithGivenCoexponentials( B_, IdentityMorphism( TerminalObject( CapCategory( u ) ) ), u, A_ );
+    return CoexponentialOnMorphismsWithGivenCoexponentials( cat, B_, IdentityMorphism( cat, TerminalObject( cat ) ), u, A_ );
     
 end : Description := "ConegationOnMorphismsWithGivenConegations using CoexponentialOnMorphismsWithGivenCoexponentials and IdentityMorphism and TerminalObject",
       CategoryFilter := IsThinCategory and IsCartesianCategory and IsCocartesianCategory and IsCocartesianCoclosedCategory );

--- a/gap/ConstructibleObjectsAsUnionOfMultipleDifferences.gi
+++ b/gap/ConstructibleObjectsAsUnionOfMultipleDifferences.gi
@@ -50,6 +50,8 @@ InstallMethod( BooleanAlgebraOfConstructibleObjectsAsUnionOfMultipleDifferences,
     
     C := CreateCapCategory( name );
     
+    C!.category_as_first_argument := true;
+    
     SetIsCartesianClosedCategoryWithIsomorphicDoubleNegations( C, true );
     SetIsCocartesianCoclosedCategoryWithIsomorphicDoubleConegations( C, true );
     
@@ -64,7 +66,7 @@ InstallMethod( BooleanAlgebraOfConstructibleObjectsAsUnionOfMultipleDifferences,
     
     ##
     AddIsWellDefinedForObjects( C,
-      function( A )
+      function( cat, A )
         
         return ForAll( A, IsWellDefinedForObjects );
         
@@ -72,7 +74,7 @@ InstallMethod( BooleanAlgebraOfConstructibleObjectsAsUnionOfMultipleDifferences,
     
     ##
     AddIsHomSetInhabited( C,
-      function( A, B )
+      function( cat, A, B )
         
         return ForAll( A, M -> IsHomSetInhabitedWithTypeCast( M, B ) );
         
@@ -80,7 +82,7 @@ InstallMethod( BooleanAlgebraOfConstructibleObjectsAsUnionOfMultipleDifferences,
     
     ##
     AddTerminalObject( C,
-      function( arg )
+      function( cat )
         local T;
         
         T := TerminalObject( C!.MeetSemilatticeOfMultipleDifferences );
@@ -91,7 +93,7 @@ InstallMethod( BooleanAlgebraOfConstructibleObjectsAsUnionOfMultipleDifferences,
     
     ##
     AddInitialObject( C,
-      function( arg )
+      function( cat )
         local I;
         
         I := InitialObject( C!.MeetSemilatticeOfMultipleDifferences );
@@ -102,7 +104,7 @@ InstallMethod( BooleanAlgebraOfConstructibleObjectsAsUnionOfMultipleDifferences,
     
     ##
     AddIsInitial( C,
-      function( A )
+      function( cat, A )
         
         return ForAll( A, IsInitial );
         
@@ -127,7 +129,7 @@ InstallMethod( BooleanAlgebraOfConstructibleObjectsAsUnionOfMultipleDifferences,
     
     ##
     AddDirectProduct( C,
-      function( L )
+      function( cat, L )
         
         return Iterated( L, BinaryDirectProduct );
         
@@ -135,7 +137,7 @@ InstallMethod( BooleanAlgebraOfConstructibleObjectsAsUnionOfMultipleDifferences,
     
     ##
     AddCoproduct( C,
-      function( L )
+      function( cat, L )
         
         L := List( L, List );
         

--- a/gap/ConstructibleObjectsAsUnionOfSingleDifferences.gi
+++ b/gap/ConstructibleObjectsAsUnionOfSingleDifferences.gi
@@ -47,6 +47,8 @@ InstallMethod( BooleanAlgebraOfConstructibleObjectsAsUnionOfDifferences,
     
     C := CreateCapCategory( name );
     
+    C!.category_as_first_argument := true;
+    
     SetIsCartesianClosedCategoryWithIsomorphicDoubleNegations( C, true );
     SetIsCocartesianCoclosedCategoryWithIsomorphicDoubleConegations( C, true );
     
@@ -61,7 +63,7 @@ InstallMethod( BooleanAlgebraOfConstructibleObjectsAsUnionOfDifferences,
     
     ##
     AddIsWellDefinedForObjects( C,
-      function( A )
+      function( cat, A )
         
         return ForAll( A, IsWellDefinedForObjects );
         
@@ -69,7 +71,7 @@ InstallMethod( BooleanAlgebraOfConstructibleObjectsAsUnionOfDifferences,
     
     ##
     AddIsHomSetInhabited( C,
-      function( A, B )
+      function( cat, A, B )
         
         return ForAll( A, M -> IsHomSetInhabitedWithTypeCast( M, B ) );
         
@@ -77,7 +79,7 @@ InstallMethod( BooleanAlgebraOfConstructibleObjectsAsUnionOfDifferences,
     
     ##
     AddTerminalObject( C,
-      function( arg )
+      function( cat )
         local T;
         
         T := TerminalObject( C!.MeetSemilatticeOfDifferences );
@@ -88,7 +90,7 @@ InstallMethod( BooleanAlgebraOfConstructibleObjectsAsUnionOfDifferences,
     
     ##
     AddInitialObject( C,
-      function( arg )
+      function( cat )
         local I;
         
         I := InitialObject( C!.MeetSemilatticeOfDifferences );
@@ -99,7 +101,7 @@ InstallMethod( BooleanAlgebraOfConstructibleObjectsAsUnionOfDifferences,
     
     ##
     AddIsInitial( C,
-      function( A )
+      function( cat, A )
         
         return ForAll( A, IsInitial );
         
@@ -124,7 +126,7 @@ InstallMethod( BooleanAlgebraOfConstructibleObjectsAsUnionOfDifferences,
     
     ##
     AddDirectProduct( C,
-      function( L )
+      function( cat, L )
         
         return Iterated( L, BinaryDirectProduct );
         
@@ -132,7 +134,7 @@ InstallMethod( BooleanAlgebraOfConstructibleObjectsAsUnionOfDifferences,
     
     ##
     AddCoproduct( C,
-      function( L )
+      function( cat, L )
         
         L := List( L, List );
         

--- a/gap/HeytingAlgebra.gi
+++ b/gap/HeytingAlgebra.gi
@@ -8,7 +8,7 @@ InstallValue( HEYTING_ALGEBRA_METHOD_NAME_RECORD,
         rec(
 NegationOnObjects := rec(
   installation_name := "NegationOnObjects",
-  filter_list := [ "object" ],
+  filter_list := [ "category", "object" ],
   io_type := [ [ "a" ], [ "an" ] ],
   cache_name := "NegationOnObjects",
   return_type := "object" ),
@@ -16,13 +16,13 @@ NegationOnObjects := rec(
 NegationOnMorphismsWithGivenNegations := rec(
   installation_name := "NegationOnMorphismsWithGivenNegations",
   io_type := [ [ "s", "alpha", "r" ], [ "s", "r" ] ],
-  filter_list := [ "object", "morphism", "object" ],
+  filter_list := [ "category", "object", "morphism", "object" ],
   cache_name := "NegationOnMorphismsWithGivenNegations",
   return_type := "morphism" ),
 
 MorphismToDoubleNegationWithGivenDoubleNegation := rec(
   installation_name := "MorphismToDoubleNegationWithGivenDoubleNegation",
-  filter_list := [ "object", "object" ],
+  filter_list := [ "category", "object", "object" ],
   io_type := [ [ "a", "r" ], [ "a", "r" ] ],
   cache_name := "MorphismToDoubleNegationWithGivenDoubleNegation",
   return_type := "morphism" )
@@ -158,7 +158,7 @@ AddDerivationToCAP( IsHomSetInhabited,
         
   function( cat, S, T )
     
-    return IsTerminal( ExponentialOnObjects( S, T ) );
+    return IsTerminal( cat, ExponentialOnObjects( cat, S, T ) );
     
 end : Description := "IsHomSetInhabited using IsTerminal and ExponentialOnObjects",
       CategoryFilter := IsThinCategory and IsCartesianClosedCategory );
@@ -168,9 +168,9 @@ AddDerivationToCAP( NegationOnObjects,
         [ [ ExponentialOnObjects, 1 ],
           [ InitialObject, 1 ] ],
         
-  function( A )
+  function( cat, A )
     
-    return ExponentialOnObjects( A, InitialObject( CapCategory( A ) ) );
+    return ExponentialOnObjects( cat, A, InitialObject( cat ) );
     
 end : Description := "NegationOnObjects using ExponentialOnObjects and InitialObject",
       CategoryFilter := IsThinCategory and IsCartesianClosedCategory );
@@ -181,9 +181,9 @@ AddDerivationToCAP( NegationOnMorphismsWithGivenNegations,
           [ IdentityMorphism, 1 ],
           [ InitialObject, 1 ] ],
         
-  function( B_, u, A_ )
+  function( cat, B_, u, A_ )
     
-    return ExponentialOnMorphismsWithGivenExponentials( B_, u, IdentityMorphism( InitialObject( CapCategory( u ) ) ), A_ );
+    return ExponentialOnMorphismsWithGivenExponentials( cat, B_, u, IdentityMorphism( cat, InitialObject( cat ) ), A_ );
     
 end : Description := "NegationOnMorphismsWithGivenNegations using ExponentialOnMorphismsWithGivenExponentials and IdentityMorphism and InitialObject",
       CategoryFilter := IsThinCategory and IsCartesianCategory and IsCocartesianCategory and IsCartesianClosedCategory );

--- a/gap/HeytingAlgebra.gi
+++ b/gap/HeytingAlgebra.gi
@@ -69,7 +69,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_HEYTING_ALGEBRAS,
     
     ##
     AddExponentialOnMorphismsWithGivenExponentials( heyting_algebra,
-      function( S, alpha, beta, R )
+      function( cat, S, alpha, beta, R )
         
         return UniqueMorphism( S, R );
         
@@ -77,7 +77,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_HEYTING_ALGEBRAS,
     
     ##
     AddCartesianEvaluationMorphismWithGivenSource( heyting_algebra,
-      function( A, B, Exp_A_BxA )
+      function( cat, A, B, Exp_A_BxA )
         
         return UniqueMorphism( Exp_A_BxA, B);
         
@@ -85,7 +85,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_HEYTING_ALGEBRAS,
     
     ##
     AddCartesianCoevaluationMorphismWithGivenRange( heyting_algebra,
-      function( A, B, Exp_B_AxB )
+      function( cat, A, B, Exp_B_AxB )
         
         return UniqueMorphism( A, Exp_B_AxB );
         
@@ -93,7 +93,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_HEYTING_ALGEBRAS,
     
     ##
     AddDirectProductToExponentialAdjunctionMap( heyting_algebra,
-      function( A, B, f )
+      function( cat, A, B, f )
         local L;
         
         L := Range( f );
@@ -104,7 +104,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_HEYTING_ALGEBRAS,
     
     ##
     AddExponentialToDirectProductAdjunctionMap( heyting_algebra,
-      function( B, C, g )
+      function( cat, B, C, g )
         local A, AB;
         
         A := Source( g );
@@ -117,7 +117,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_HEYTING_ALGEBRAS,
     
     ##
     AddCartesianPreComposeMorphismWithGivenObjects( heyting_algebra,
-      function( Exp_A_BxExp_B_C, A, B, C, Exp_A_C );
+      function( cat, Exp_A_BxExp_B_C, A, B, C, Exp_A_C );
         
         return UniqueMorphism( Exp_A_BxExp_B_C, Exp_A_C );
         
@@ -125,7 +125,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_HEYTING_ALGEBRAS,
     
     ##
     AddCartesianPostComposeMorphismWithGivenObjects( heyting_algebra,
-      function( Exp_B_CxExp_A_B, A, B, C, Exp_A_C );
+      function( cat, Exp_B_CxExp_A_B, A, B, C, Exp_A_C );
         
         return UniqueMorphism( Exp_B_CxExp_A_B, Exp_A_C );
         
@@ -133,7 +133,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_HEYTING_ALGEBRAS,
     
     ##
     AddDirectProductExponentialCompatibilityMorphismWithGivenObjects( heyting_algebra,
-      function( A1, A2, B1, B2, L )
+      function( cat, A1, A2, B1, B2, L )
         
         return UniqueMorphism( L[1], L[2] );
         
@@ -143,7 +143,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_HEYTING_ALGEBRAS,
     
     ##
     AddMorphismToDoubleNegationWithGivenDoubleNegation( heyting_algebra,
-      function( A, B )
+      function( cat, A, B )
         
         return UniqueMorphism( A, B );
         

--- a/gap/Lattice.gi
+++ b/gap/Lattice.gi
@@ -116,7 +116,7 @@ AddDerivationToCAP( IsHomSetInhabited,
         
   function( cat, S, T )
     
-    return AreIsomorphicForObjectsIfIsHomSetInhabited( DirectProduct( S, T ), S );
+    return AreIsomorphicForObjectsIfIsHomSetInhabited( cat, DirectProduct( cat, S, T ), S );
     
 end : Description := "IsHomSetInhabited using AreIsomorphicForObjectsIfIsHomSetInhabited and DirectProduct",
       CategoryFilter := IsThinCategory and IsCartesianCategory );
@@ -238,7 +238,7 @@ AddDerivationToCAP( IsHomSetInhabited,
         
   function( cat, S, T )
     
-    return AreIsomorphicForObjectsIfIsHomSetInhabited( T, Coproduct( S, T ) );
+    return AreIsomorphicForObjectsIfIsHomSetInhabited( cat, T, Coproduct( cat, S, T ) );
     
 end : Description := "IsHomSetInhabited using AreIsomorphicForObjectsIfIsHomSetInhabited and Coproduct",
       CategoryFilter := IsThinCategory and IsCocartesianCategory );

--- a/gap/Lattice.gi
+++ b/gap/Lattice.gi
@@ -21,7 +21,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_CARTESIAN_PREORDERED_SETS,
     
     ##
     AddProjectionInFactorOfDirectProductWithGivenDirectProduct( cartesian_proset,
-      function( D, k, P )
+      function( cat, D, k, P )
         
         return UniqueMorphism( P, D[k] );
         
@@ -29,7 +29,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_CARTESIAN_PREORDERED_SETS,
     
     ##
     AddUniversalMorphismIntoDirectProductWithGivenDirectProduct( cartesian_proset,
-      function( D, test_object, tau, P )
+      function( cat, D, test_object, tau, P )
         
         return UniqueMorphism( Source( tau[1] ), P );
         
@@ -37,7 +37,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_CARTESIAN_PREORDERED_SETS,
     
     ##
     AddDirectProductFunctorialWithGivenDirectProducts( cartesian_proset,
-      function( s, source_diagram, L, range_diagram, r )
+      function( cat, s, source_diagram, L, range_diagram, r )
         
         return UniqueMorphism( s, r );
         
@@ -45,7 +45,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_CARTESIAN_PREORDERED_SETS,
     
     ##
     AddCartesianAssociatorRightToLeftWithGivenDirectProducts( cartesian_proset,
-      function( s, a, b, c, r )
+      function( cat, s, a, b, c, r )
         
         return UniqueMorphism( s, r );
         
@@ -53,7 +53,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_CARTESIAN_PREORDERED_SETS,
     
     ##
     AddCartesianAssociatorLeftToRightWithGivenDirectProducts( cartesian_proset,
-      function( s, a, b, c, r )
+      function( cat, s, a, b, c, r )
         
         return UniqueMorphism( s, r );
         
@@ -61,7 +61,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_CARTESIAN_PREORDERED_SETS,
     
     ##
     AddCartesianLeftUnitorWithGivenDirectProduct( cartesian_proset,
-      function( M, TM )
+      function( cat, M, TM )
         
         return UniqueMorphism( TM, M );
         
@@ -69,7 +69,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_CARTESIAN_PREORDERED_SETS,
     
     ##
     AddCartesianLeftUnitorInverseWithGivenDirectProduct( cartesian_proset,
-      function( M, TM )
+      function( cat, M, TM )
         
         return UniqueMorphism( M, TM );
         
@@ -77,7 +77,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_CARTESIAN_PREORDERED_SETS,
     
     ##
     AddCartesianRightUnitorWithGivenDirectProduct( cartesian_proset,
-      function( M, MT )
+      function( cat, M, MT )
         
         return UniqueMorphism( MT, M );
         
@@ -85,7 +85,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_CARTESIAN_PREORDERED_SETS,
     
     ##
     AddCartesianRightUnitorInverseWithGivenDirectProduct( cartesian_proset,
-      function( M, MT )
+      function( cat, M, MT )
         
         return UniqueMorphism( M, MT );
         
@@ -93,7 +93,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_CARTESIAN_PREORDERED_SETS,
     
     ##
     AddCartesianBraidingWithGivenDirectProducts( cartesian_proset,
-      function( MN, M, N, NM )
+      function( cat, MN, M, N, NM )
         
         return UniqueMorphism( MN, NM );
         
@@ -101,7 +101,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_CARTESIAN_PREORDERED_SETS,
     
     ##
     AddCartesianBraidingInverseWithGivenDirectProducts( cartesian_proset,
-      function( NM, M, N, MN )
+      function( cat, NM, M, N, MN )
         
         return UniqueMorphism( NM, MN );
         
@@ -143,7 +143,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_COCARTESIAN_PREORDERED_SETS,
     
     ##
     AddInjectionOfCofactorOfCoproductWithGivenCoproduct( cocartesian_proset,
-      function( D, k, I )
+      function( cat, D, k, I )
         
         return UniqueMorphism( D[k], I );
         
@@ -151,7 +151,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_COCARTESIAN_PREORDERED_SETS,
     
     ##
     AddUniversalMorphismFromCoproductWithGivenCoproduct( cocartesian_proset,
-      function( D, test_object, tau, I )
+      function( cat, D, test_object, tau, I )
         
         return UniqueMorphism( I, Range( tau[1] ) );
         
@@ -159,7 +159,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_COCARTESIAN_PREORDERED_SETS,
     
     ##
     AddCoproductFunctorialWithGivenCoproducts( cocartesian_proset,
-      function( s, source_diagram, L, range_diagram, r )
+      function( cat, s, source_diagram, L, range_diagram, r )
         
         return UniqueMorphism( s, r );
         
@@ -167,7 +167,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_COCARTESIAN_PREORDERED_SETS,
     
     ##
     AddCocartesianAssociatorRightToLeftWithGivenCoproducts( cocartesian_proset,
-      function( s, a, b, c, r )
+      function( cat, s, a, b, c, r )
         
         return UniqueMorphism( s, r );
         
@@ -175,7 +175,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_COCARTESIAN_PREORDERED_SETS,
     
     ##
     AddCocartesianAssociatorLeftToRightWithGivenCoproducts( cocartesian_proset,
-      function( s, a, b, c, r )
+      function( cat, s, a, b, c, r )
         
         return UniqueMorphism( s, r );
         
@@ -183,7 +183,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_COCARTESIAN_PREORDERED_SETS,
     
     ##
     AddCocartesianLeftUnitorWithGivenCoproduct( cocartesian_proset,
-      function( M, TM )
+      function( cat, M, TM )
         
         return UniqueMorphism( TM, M );
         
@@ -191,7 +191,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_COCARTESIAN_PREORDERED_SETS,
     
     ##
     AddCocartesianLeftUnitorInverseWithGivenCoproduct( cocartesian_proset,
-      function( M, TM )
+      function( cat, M, TM )
         
         return UniqueMorphism( M, TM );
         
@@ -199,7 +199,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_COCARTESIAN_PREORDERED_SETS,
     
     ##
     AddCocartesianRightUnitorWithGivenCoproduct( cocartesian_proset,
-      function( M, MT )
+      function( cat, M, MT )
         
         return UniqueMorphism( MT, M );
         
@@ -207,7 +207,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_COCARTESIAN_PREORDERED_SETS,
     
     ##
     AddCocartesianRightUnitorInverseWithGivenCoproduct( cocartesian_proset,
-      function( M, MT )
+      function( cat, M, MT )
         
         return UniqueMorphism( M, MT );
         
@@ -215,7 +215,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_COCARTESIAN_PREORDERED_SETS,
     
     ##
     AddCocartesianBraidingWithGivenCoproducts( cocartesian_proset,
-      function( MN, M, N, NM )
+      function( cat, MN, M, N, NM )
         
         return UniqueMorphism( MN, NM );
         
@@ -223,7 +223,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_COCARTESIAN_PREORDERED_SETS,
     
     ##
     AddCocartesianBraidingInverseWithGivenCoproducts( cocartesian_proset,
-      function( NM, M, N, MN )
+      function( cat, NM, M, N, MN )
         
         return UniqueMorphism( NM, MN );
         

--- a/gap/MultipleDifferences.gi
+++ b/gap/MultipleDifferences.gi
@@ -18,6 +18,8 @@ InstallMethod( MeetSemilatticeOfMultipleDifferences,
     
     D := CreateCapCategory( name );
     
+    D!.category_as_first_argument := true;
+    
     D!.UnderlyingCategory := P;
     D!.MeetSemilatticeOfDifferences := MeetSemilatticeOfDifferences( P );
     
@@ -31,7 +33,7 @@ InstallMethod( MeetSemilatticeOfMultipleDifferences,
     
     ##
     AddIsWellDefinedForObjects( D,
-      function( A )
+      function( cat, A )
         
         return ForAll( A, IsObjectInMeetSemilatticeOfSingleDifferences ) and ForAll( A, IsWellDefinedForObjects );
         
@@ -39,7 +41,7 @@ InstallMethod( MeetSemilatticeOfMultipleDifferences,
     
     ##
     AddIsHomSetInhabited( D,
-      function( A, B )
+      function( cat, A, B )
         
         return IsInitial( A - B.I ) and ForAll( B, d -> IsInitial( A * d.J ) );
         
@@ -47,7 +49,7 @@ InstallMethod( MeetSemilatticeOfMultipleDifferences,
     
     ##
     AddTerminalObject( D,
-      function( arg )
+      function( cat )
         local T;
         
         T := TerminalObject( D!.MeetSemilatticeOfDifferences );
@@ -58,7 +60,7 @@ InstallMethod( MeetSemilatticeOfMultipleDifferences,
     
     ##
     AddInitialObject( D,
-      function( arg )
+      function( cat )
         local I;
         
         I := InitialObject( D!.MeetSemilatticeOfDifferences );
@@ -69,7 +71,7 @@ InstallMethod( MeetSemilatticeOfMultipleDifferences,
     
     ##
     AddIsInitial( D,
-      function( A )
+      function( cat, A )
         
         return IsInitial( AsSingleDifference( A ) );
         
@@ -77,7 +79,7 @@ InstallMethod( MeetSemilatticeOfMultipleDifferences,
     
     ##
     AddDirectProduct( D,
-      function( L )
+      function( cat, L )
         
         L := List( L, List );
         

--- a/gap/Poset.gi
+++ b/gap/Poset.gi
@@ -8,7 +8,7 @@ InstallValue( POSET_METHOD_NAME_RECORD,
         rec(
             IsEqualForObjectsIfIsHomSetInhabited := rec(
                                      installation_name := "IsEqualForObjectsIfIsHomSetInhabited",
-                                     filter_list := [ "object", "object" ],
+                                     filter_list := [ "category", "object", "object" ],
                                      return_type := "bool",
                                      is_merely_set_theoretic := true
                                     ),
@@ -33,7 +33,7 @@ end );
 AddDerivationToCAP( IsEqualForObjectsIfIsHomSetInhabited,
         [ [ AreIsomorphicForObjectsIfIsHomSetInhabited, 1 ] ],
         
-  AreIsomorphicForObjectsIfIsHomSetInhabited :
+  { cat, A, B } -> AreIsomorphicForObjectsIfIsHomSetInhabited( cat, A, B ) :
       Description := "AreIsomorphicForObjectsIfIsHomSetInhabited using AreIsomorphicForObjectsIfIsHomSetInhabited",
       CategoryFilter := IsThinCategory and IsSkeletalCategory );
 
@@ -44,8 +44,8 @@ AddDerivationToCAP( IsEqualForObjects,
         
   function( cat, A, B )
     
-    return IsHomSetInhabited( A, B ) and
-           AreIsomorphicForObjectsIfIsHomSetInhabited( A, B );
+    return IsHomSetInhabited( cat, A, B ) and
+           AreIsomorphicForObjectsIfIsHomSetInhabited( cat, A, B );
         
 end : Description := "",
       CategoryFilter := IsThinCategory and IsSkeletalCategory );

--- a/gap/Proset.gi
+++ b/gap/Proset.gi
@@ -56,7 +56,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_PREORDERED_SETS,
     
     ##
     AddIsWellDefinedForMorphisms( preordered_set,
-      function( u )
+      function( cat, u )
         
         return IsHomSetInhabited( Source( u ), Range( u ) );
         
@@ -64,11 +64,11 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_PREORDERED_SETS,
     
     ##
     AddIsEqualForCacheForObjects( preordered_set,
-      IsIdenticalObj );
+      { cat, obj1, obj2 } -> IsIdenticalObj( obj1, obj2 ) );
     
     ##
     AddIsEqualForCacheForMorphisms( preordered_set,
-      function( u1, u2 )
+      function( cat, u1, u2 )
         
         return IsEqualForCacheForObjects( Source( u1 ), Source( u2 ) ) and
                IsEqualForCacheForObjects( Range( u1 ), Range( u2 ) );
@@ -77,7 +77,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_PREORDERED_SETS,
     
     ##
     AddIdentityMorphism( preordered_set,
-      function( A )
+      function( cat, A )
         
         return UniqueMorphism( A, A );
         
@@ -85,7 +85,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_PREORDERED_SETS,
     
     ##
     AddPreCompose( preordered_set,
-      function( u1, u2 )
+      function( cat, u1, u2 )
         
         return UniqueMorphism( Source( u1 ), Range( u2 ) );
         
@@ -93,19 +93,19 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_PREORDERED_SETS,
     
     ##
     AddIsMonomorphism( preordered_set,
-      ReturnTrue );
+      { cat, alpha } -> true );
     
     ##
     AddIsEpimorphism( preordered_set,
-      ReturnTrue );
+      { cat, alpha } -> true );
     
     ##
     AddIsOne( preordered_set,
-      IsAutomorphism );
+      { cat, alpha } -> IsAutomorphism( cat, alpha ) );
     
     ##
     AddLiftAlongMonomorphism( preordered_set,
-      function( u1, u2 )
+      function( cat, u1, u2 )
         
         if not IsDominating( u1, u2 ) then
             return fail;
@@ -117,7 +117,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_PREORDERED_SETS,
     
     ##
     AddColiftAlongEpimorphism( preordered_set,
-      function( u1, u2 )
+      function( cat, u1, u2 )
         
         if not IsCodominating( u2, u1 ) then
             return fail;
@@ -129,7 +129,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_PREORDERED_SETS,
     
     ##
     AddInverseForMorphisms( preordered_set,
-      function( u )
+      function( cat, u )
         
         return UniqueMorphism( Range( u ), Source( u ) );
         
@@ -137,7 +137,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_PREORDERED_SETS,
     
     ##
     AddUniversalMorphismIntoTerminalObjectWithGivenTerminalObject( preordered_set,
-      function( A, T )
+      function( cat, A, T )
         
         return UniqueMorphism( A, T );
         
@@ -145,7 +145,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_PREORDERED_SETS,
     
     ##
     AddUniversalMorphismFromInitialObjectWithGivenInitialObject( preordered_set,
-      function( A, I )
+      function( cat, A, I )
         
         return UniqueMorphism( I, A );
         
@@ -153,7 +153,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_PREORDERED_SETS,
     
     ##
     AddUniversalMorphismIntoEqualizerWithGivenEqualizer( preordered_set,
-      function( D, test_object, tau, E )
+      function( cat, D, test_object, tau, E )
         
         return UniqueMorphism( Source( tau ), E );
         
@@ -161,7 +161,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_PREORDERED_SETS,
     
     ##
     AddEqualizerFunctorialWithGivenEqualizers( preordered_set,
-      function( s, L1, m, L3, r )
+      function( cat, s, L1, m, L3, r )
         
         return UniqueMorphism( s, r );
         
@@ -169,7 +169,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_PREORDERED_SETS,
     
     ##
     AddUniversalMorphismFromCoequalizerWithGivenCoequalizer( preordered_set,
-      function( D, test_object, tau, C )
+      function( cat, D, test_object, tau, C )
         
         return UniqueMorphism( C, Range( tau ) );
         
@@ -177,7 +177,7 @@ InstallGlobalFunction( ADD_COMMON_METHODS_FOR_PREORDERED_SETS,
     
     ##
     AddCoequalizerFunctorialWithGivenCoequalizers( preordered_set,
-      function( s, L1, m, L3, r )
+      function( cat, s, L1, m, L3, r )
         
         return UniqueMorphism( s, r );
         

--- a/gap/Proset.gi
+++ b/gap/Proset.gi
@@ -10,7 +10,7 @@ InstallValue( PREORDERED_SET_METHOD_NAME_RECORD,
         rec(
             AreIsomorphicForObjectsIfIsHomSetInhabited := rec(
                                      installation_name := "AreIsomorphicForObjectsIfIsHomSetInhabited",
-                                     filter_list := [ "object", "object" ],
+                                     filter_list := [ "category", "object", "object" ],
                                      return_type := "bool",
                                      is_merely_set_theoretic := true
                                     ),
@@ -191,8 +191,8 @@ AddDerivationToCAP( IsEqualForMorphisms,
         
   function( cat, u1, u2 )
     
-    return IsEqualForObjects( Source( u1 ), Source( u2 ) ) and
-           IsEqualForObjects( Range( u1 ), Range( u2 ) );
+    return IsEqualForObjects( cat, Source( u1 ), Source( u2 ) ) and
+           IsEqualForObjects( cat, Range( u1 ), Range( u2 ) );
         
 end : Description := "IsEqualForMorphisms using IsEqualForObjects applied to sources and ranges",
       CategoryFilter := IsThinCategory );
@@ -201,9 +201,9 @@ end : Description := "IsEqualForMorphisms using IsEqualForObjects applied to sou
 AddDerivationToCAP( AreIsomorphicForObjectsIfIsHomSetInhabited,
         [ [ IsHomSetInhabited, 1 ] ],
         
-  function( A, B )
+  function( cat, A, B )
     
-    return IsHomSetInhabited( B, A );
+    return IsHomSetInhabited( cat, B, A );
     
 end : Description := "AreIsomorphicForObjectsIfIsHomSetInhabited using IsHomSetInhabited",
       CategoryFilter := IsThinCategory );
@@ -215,7 +215,7 @@ AddDerivationToCAP( IsTerminal,
         
   function( cat, A )
     
-    return AreIsomorphicForObjectsIfIsHomSetInhabited( A, TerminalObject( cat ) );
+    return AreIsomorphicForObjectsIfIsHomSetInhabited( cat, A, TerminalObject( cat, cat ) );
     
 end : Description := "IsTerminal using AreIsomorphicForObjectsIfIsHomSetInhabited and TerminalObject",
       CategoryFilter := IsThinCategory );
@@ -227,7 +227,7 @@ AddDerivationToCAP( IsInitial,
         
   function( cat, A )
     
-    return AreIsomorphicForObjectsIfIsHomSetInhabited( InitialObject( cat ), A );
+    return AreIsomorphicForObjectsIfIsHomSetInhabited( cat, InitialObject( cat ), A );
     
 end : Description := "IsInitial using AreIsomorphicForObjectsIfIsHomSetInhabited and InitialObject",
       CategoryFilter := IsThinCategory );
@@ -238,7 +238,7 @@ AddDerivationToCAP( IsDominating,
         
   function( cat, u1, u2 )
     
-    return IsHomSetInhabited( Source( u1 ), Source( u2 ) );
+    return IsHomSetInhabited( cat, Source( u1 ), Source( u2 ) );
     
 end : Description := "IsDominating using IsHomSetInhabited applied to the sources",
       CategoryFilter := IsThinCategory );
@@ -249,7 +249,7 @@ AddDerivationToCAP( IsCodominating,
         
   function( cat, u1, u2 )
     
-    return IsHomSetInhabited( Range( u2 ), Range( u1 ) );
+    return IsHomSetInhabited( cat, Range( u2 ), Range( u1 ) );
     
 end : Description := "IsCodominating using IsHomSetInhabited applied to the ranges",
       CategoryFilter := IsThinCategory );
@@ -271,7 +271,7 @@ AddDerivationToCAP( EmbeddingOfEqualizerWithGivenEqualizer,
         
   function( cat, D, E )
     
-    return IdentityMorphism( E );
+    return IdentityMorphism( cat, E );
     
 end : Description := "EmbeddingOfEqualizerWithGivenEqualizer using IdentityMorphism",
       CategoryFilter := IsThinCategory );
@@ -293,7 +293,7 @@ AddDerivationToCAP( ProjectionOntoCoequalizerWithGivenCoequalizer,
         
   function( cat, D, C )
     
-    return IdentityMorphism( C );
+    return IdentityMorphism( cat, C );
     
 end : Description := "ProjectionOntoCoequalizerWithGivenCoequalizer using IdentityMorphism",
       CategoryFilter := IsThinCategory );
@@ -302,7 +302,8 @@ end : Description := "ProjectionOntoCoequalizerWithGivenCoequalizer using Identi
 AddDerivationToCAP( Lift,
         [ [ LiftAlongMonomorphism, 1 ] ],
         
-  LiftAlongMonomorphism :
+  ## Caution with the order of the arguments!
+  { cat, alpha, beta } -> LiftAlongMonomorphism( cat, beta, alpha ) :
       Description := "Lift using LiftAlongMonomorphism",
       CategoryFilter := IsThinCategory );
 
@@ -310,20 +311,20 @@ AddDerivationToCAP( Lift,
 AddDerivationToCAP( Colift,
         [ [ LiftAlongMonomorphism, 1 ] ],
         
-  ColiftAlongEpimorphism :
+  { cat, alpha, beta } -> ColiftAlongEpimorphism( cat, alpha, beta ) :
       Description := "Colift using ColiftAlongEpimorphism",
       CategoryFilter := IsThinCategory );
 
 ##
 AddDerivationToCAP( IsMonomorphism,
         
-  ReturnTrue : Description := "IsMonomorphism is always true",
+  { cat, alpha } -> true : Description := "IsMonomorphism is always true",
       CategoryFilter := IsThinCategory );
 
 ##
 AddDerivationToCAP( IsEpimorphism,
         
-  ReturnTrue : Description := "IsEpimorphism is always true",
+  { cat, alpha } -> true : Description := "IsEpimorphism is always true",
       CategoryFilter := IsThinCategory );
 
 ##
@@ -332,7 +333,7 @@ AddDerivationToCAP( IsIsomorphism,
         
   function( cat, u )
     
-    return IsHomSetInhabited( Range( u ), Source( u ) );
+    return IsHomSetInhabited( cat, Range( u ), Source( u ) );
     
 end : Description := "IsIsomorphism using IsHomSetInhabited",
       CategoryFilter := IsThinCategory );

--- a/gap/ProsetOfCategory.gi
+++ b/gap/ProsetOfCategory.gi
@@ -7,12 +7,45 @@
 ##
 InstallValue( CAP_INTERNAL_METHOD_NAME_LIST_FOR_PREORDERED_SET_OF_CATEGORY,
   [
+   # create_func_bool and create_func_object can only deal with operations which do
+   # not get morphisms as arguments, because they access `UnderlyingCell` which is
+   # not set for morphisms
    "IsWellDefinedForObjects",
    "IsHomSetInhabited",
    "TensorUnit",
    "TensorProductOnObjects",
    "InternalHomOnObjects",
    "InternalHomOnMorphismsWithGivenInternalHoms",
+   # P admits the same (co)limits as C,
+   # in fact, a weak (co)limit in C becomes a (co)limit in P.
+   # However, we must not automatically detect these (co)limits via `universal_type`,
+   # because `universal_type` is sometimes set for technical instead of mathematical reasons.
+   # Additionally, we must be careful with the restrictions of create_func_bool and create_func_object
+   # mentioned above.
+   # DirectProduct
+   "DirectProduct",
+   "ProjectionInFactorOfDirectProductWithGivenDirectProduct",
+   "UniversalMorphismIntoDirectProductWithGivenDirectProduct",
+   # Coproduct
+   "Coproduct",
+   "InjectionOfCofactorOfCoproductWithGivenCoproduct",
+   "UniversalMorphismFromCoproductWithGivenCoproduct",
+   # DirectSum
+   "DirectSum",
+   "ProjectionInFactorOfDirectSumWithGivenDirectSum",
+   "InjectionOfCofactorOfDirectSumWithGivenDirectSum",
+   "UniversalMorphismIntoDirectSumWithGivenDirectSum",
+   "UniversalMorphismFromDirectSumWithGivenDirectSum",
+   # TerminalObject
+   "TerminalObject",
+   "UniversalMorphismIntoTerminalObjectWithGivenTerminalObject",
+   # InitialObject
+   "InitialObject",
+   "UniversalMorphismFromInitialObjectWithGivenInitialObject",
+   # ZeroObject
+   "ZeroObject",
+   "UniversalMorphismIntoZeroObjectWithGivenZeroObject",
+   "UniversalMorphismFromZeroObjectWithGivenZeroObject",
    ] );
 
 ##
@@ -237,7 +270,7 @@ InstallMethod( CreateProsetOrPosetOfCategory,
   function( C )
     local skeletal, stable, category_filter, category_object_filter, category_morphism_filter,
           name, create_func_bool, create_func_object, create_func_morphism,
-          list_of_operations_to_install, is_limit, skip, func, pos,
+          list_of_operations_to_install, skip, func, pos,
           properties, preinstall, P, finalize;
     
     skeletal := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "skeletal", false );
@@ -325,31 +358,11 @@ InstallMethod( CreateProsetOrPosetOfCategory,
           
       end;
     
-    is_limit :=
-      function( a )
-        local entry;
-        
-        entry := CAP_INTERNAL_METHOD_NAME_RECORD.(a);
-        
-        if IsBound( entry.universal_type ) and entry.universal_type in [ "Limit", "limit", "Colimit", "colimit" ] then
-            return true;
-        fi;
-        
-        return false;
-        
-    end;
-
-    ## P admits the same (co)limits as C,
-    ## in fact, a weak (co)limit in C becomes a (co)limit in P
-    list_of_operations_to_install := Filtered( ListInstalledOperationsOfCategory( C ), is_limit );
+    list_of_operations_to_install := Intersection(
+        CAP_INTERNAL_METHOD_NAME_LIST_FOR_PREORDERED_SET_OF_CATEGORY,
+        ListInstalledOperationsOfCategory( C )
+    );
     
-    list_of_operations_to_install :=
-      Concatenation(
-              Intersection(
-                      CAP_INTERNAL_METHOD_NAME_LIST_FOR_PREORDERED_SET_OF_CATEGORY,
-                      ListInstalledOperationsOfCategory( C ) ),
-              list_of_operations_to_install );
-
     skip := [ 
               ];
     

--- a/gap/SingleDifferences.gi
+++ b/gap/SingleDifferences.gi
@@ -18,6 +18,8 @@ InstallMethod( MeetSemilatticeOfDifferences,
     
     D := CreateCapCategory( name );
     
+    D!.category_as_first_argument := true;
+    
     D!.UnderlyingCategory := P;
     
     AddObjectRepresentation( D, IsObjectInMeetSemilatticeOfSingleDifferences );
@@ -30,7 +32,7 @@ InstallMethod( MeetSemilatticeOfDifferences,
     
     ##
     AddIsWellDefinedForObjects( D,
-      function( A )
+      function( cat, A )
         local L;
         
         A := PairInUnderlyingLattice( A );
@@ -43,7 +45,7 @@ InstallMethod( MeetSemilatticeOfDifferences,
     
     ##
     AddIsHomSetInhabited( D,
-      function( A, B )
+      function( cat, A, B )
         local Ap, Bp;
         
         A := PairInUnderlyingLattice( A );
@@ -69,7 +71,7 @@ InstallMethod( MeetSemilatticeOfDifferences,
     
     ##
     AddTerminalObject( D,
-      function( arg )
+      function( cat )
         local T, I;
         
         T := TerminalObject( D!.UnderlyingCategory );
@@ -81,7 +83,7 @@ InstallMethod( MeetSemilatticeOfDifferences,
     
     ##
     AddInitialObject( D,
-      function( arg )
+      function( cat )
         local I;
         
         I := InitialObject( D!.UnderlyingCategory );
@@ -92,7 +94,7 @@ InstallMethod( MeetSemilatticeOfDifferences,
     
     ##
     AddIsInitial( D,
-      function( A )
+      function( cat, A )
         
         A := PairInUnderlyingLattice( A );
         
@@ -102,7 +104,7 @@ InstallMethod( MeetSemilatticeOfDifferences,
     
     ##
     AddDirectProduct( D,
-      function( L )
+      function( cat, L )
         local T, S;
         
         L := List( L, PairInUnderlyingLattice );

--- a/release-gap-package
+++ b/release-gap-package
@@ -43,12 +43,13 @@ Actions
   -p,  --push                      perform the final push, completing the release [Default]
   -P,  --no-push                   do not perform the final push
   -f,  --force                     if a release with the same name already exists: overwrite it
+  --skip-existing-release          if a release with the same name already exists: exit without error
 
 Paths
   --srcdir <path>                  path of directory containing PackageInfo.g [Default: current directory]
   --tmpdir <path>                  path of temporary directory [Default: tmp subdirectory of srcdir]
   --webdir <path>                  path of web directory [Default: gh-pages subdirectory of srcdir]
-  --update-file <file>             path of the update.g file [Default: update.g in webdir]
+  --update-script <file>           path of the update script [Default: update.g in webdir]
 
 Custom settings
   --token <oauth>                  GitHub access token
@@ -145,12 +146,12 @@ while [ x"$1" != x ]; do
     --srcdir ) SRC_DIR="$1"; shift ;;
     --webdir ) WEB_DIR="$1"; shift ;;
     --tmpdir ) TMP_DIR="$1"; shift ;;
-    --update-file ) UPDATE_FILE="$1"; shift ;;
+    --update-script ) UPDATE_SCRIPT="$1"; shift ;;
 
     --srcdir=*) SRC_DIR=${option#--srcdir=}; shift ;;
     --webdir=*) WEB_DIR=${option#--webdir=}; shift ;;
     --tmpdir=*) TMP_DIR=${option#--tmpdir=}; shift ;;
-    --update-file=*) UPDATE_FILE=${option#--update-file=}; shift ;;
+    --update-script=*) UPDATE_SCRIPT=${option#--update-script=}; shift ;;
 
     --token ) TOKEN="$1"; shift ;;
 
@@ -189,12 +190,12 @@ if [ ! -d "$WEB_DIR" ] ; then
     error "could not find 'webdir' with clone of your gh-pages branch"
 fi
 
-# Check for presence of update.g file
-if [ "x$UPDATE_FILE" = x ] ; then
-    UPDATE_FILE="$WEB_DIR/update.g"
+# Check for presence of the update script
+if [ "x$UPDATE_SCRIPT" = x ] ; then
+    UPDATE_SCRIPT="$WEB_DIR/update.g"
 fi
-if [ ! -f "$UPDATE_FILE" ] ; then
-    error "could not find update.g file"
+if [ ! -f "$UPDATE_SCRIPT" ] ; then
+    error "could not find update script \"${UPDATE_SCRIPT}\""
 fi
 
 # Check whether GAP is usable
@@ -416,8 +417,8 @@ sed "s;Date := .*;Date := \"$(date +%d/%m/%Y)\",;" PackageInfo.g > PackageInfo.g
 mv PackageInfo.g.bak PackageInfo.g
 
 notice "Removing unnecessary files"
-rm -rf .github .circleci
-rm -f .git* .hg* .cvs*
+# Remove recursively in case there is a .github directory
+rm -rf .git* .hg* .cvs* .circleci
 rm -f .appveyor.yml .codecov.yml .travis.yml
 
 # execute .release script, if present
@@ -447,7 +448,7 @@ fi;
 PushOptions(rec(relativePath:="../../.."));
 Read("makedoc.g");
 GAPInput
-    rm -f doc/*.lab doc/*.tex
+    rm -f doc/*.tex
     rm -f doc/*.aux doc/*.bbl doc/*.blg doc/*.brf doc/*.idx doc/*.ilg doc/*.ind doc/*.log doc/*.out doc/*.pnr doc/*.tst
 elif [ -f doc/make_doc ] ; then
     notice "Copying GAP package documentation for archives (using doc/make_doc)"
@@ -565,7 +566,7 @@ fi
 DATA=$(cat <<EOF
 {
   "tag_name": "$TAG",
-  "name": "$PKG-$VERSION",
+  "name": "$PKG $VERSION",
   "body": "Release for $PKG",
   "draft": false,
   "prerelease": false
@@ -627,7 +628,7 @@ if [ ! -f "$FULLNAME" ] ; then
 	error "could not find PDF"
 fi
 notice "Uploading PDF"
-response=$(curl --fail --progress-bar -o "$TMP_DIR/upload.log" \
+response=$(curl --fail --progress-bar -o "$TMP_DIR/upload_pdf.log" \
 	-X POST "$UPLOAD_URL/$RELEASE_ID/assets?name=$BASENAME.pdf" \
 	-H "Accept: application/vnd.github.v3+json" \
 	-H "Authorization: token $TOKEN" \
@@ -666,7 +667,7 @@ for f in ./*/*.htm* ; do
 done
 
 run_gap <<GAPInput
-Read("$UPDATE_FILE");
+Read("$UPDATE_SCRIPT");
 GAPInput
 
 git add -A


### PR DESCRIPTION
See commit messages for details.

The first commit also fixes a bug with the derivation of Lift from LiftAlongMonomorphism.