### PR TITLE
Silence warnings about wrong preconditions of derivations temporarily

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -11,7 +11,7 @@ SetPackageInfo( rec(
 
 PackageName := "Locales",
 Subtitle := "Locales, frames, coframes, meet semi-lattices of locally closed subsets, and Boolean algebras of constructible sets",
-Version := "2022.08-07",
+Version := "2022.09-01",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",

--- a/gap/ProsetDerivedMethods.gi
+++ b/gap/ProsetDerivedMethods.gi
@@ -82,6 +82,7 @@ AddDerivationToCAP( Equalizer,
     return Source( D[1] );
     
 end : Description := "Equalizer using Source",
+      ConditionsListComplete := true,
       CategoryFilter := IsThinCategory );
 
 ##
@@ -104,6 +105,7 @@ AddDerivationToCAP( Coequalizer,
     return Range( D[1] );
     
 end : Description := "Coequalizer using Range",
+      ConditionsListComplete := true,
       CategoryFilter := IsThinCategory );
 
 ##


### PR DESCRIPTION
Support for derivations with empty preconditions is on its way.