### PR TITLE
Remove workaround

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -11,7 +11,7 @@ SetPackageInfo( rec(
 
 PackageName := "Locales",
 Subtitle := "Locales, frames, coframes, meet semi-lattices of locally closed subsets, and Boolean algebras of constructible sets",
-Version := "2022.09-03",
+Version := "2022.09-04",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",

--- a/gap/ProsetDerivedMethods.gi
+++ b/gap/ProsetDerivedMethods.gi
@@ -75,11 +75,8 @@ end : Description := "IsCodominating using IsHomSetInhabited applied to the rang
 
 ##
 AddDerivationToCAP( Equalizer,
-        [ [ IsHomSetInhabited, 1 ] ], ## FIXME: this should be obsolete, there is a bug in CAP
         
   function( cat, D )
-    
-    Info( DerivationInfo, 1000, "Currently derivations without preconditions are not supported, so we have to simulate a function call here: IsHomSetInhabited( cat, obj1, obj2 )." );
     
     return Source( D[1] );
     
@@ -99,11 +96,8 @@ end : Description := "EmbeddingOfEqualizerWithGivenEqualizer using IdentityMorph
 
 ##
 AddDerivationToCAP( Coequalizer,
-        [ [ IsHomSetInhabited, 1 ] ], ## FIXME: this should be obsolete, there is a bug in CAP
         
   function( cat, D )
-    
-    Info( DerivationInfo, 1000, "Currently derivations without preconditions are not supported, so we have to simulate a function call here: IsHomSetInhabited( cat, obj1, obj2 )." );
     
     return Range( D[1] );
     


### PR DESCRIPTION
Since https://github.com/homalg-project/CAP_project/pull/1026, derivations without preconditions are handled correctly.