### PR TITLE
Fix CategoryFilter of two derivations

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -11,7 +11,7 @@ SetPackageInfo( rec(
 
 PackageName := "Locales",
 Subtitle := "Locales, frames, coframes, meet semi-lattices of locally closed subsets, and Boolean algebras of constructible sets",
-Version := "2022.09-04",
+Version := "2022.09-05",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",

--- a/gap/ProsetDerivedMethods.gi
+++ b/gap/ProsetDerivedMethods.gi
@@ -81,7 +81,7 @@ AddDerivationToCAP( Equalizer,
     return Source( D[1] );
     
 end : Description := "Equalizer using Source",
-      CategoryFilter := IsThinCategory );
+      CategoryFilter := cat -> HasIsThinCategory( cat ) and IsThinCategory( cat ) and not ( IsBound( cat!.supports_empty_limits ) and cat!.supports_empty_limits = true ) );
 
 ##
 AddDerivationToCAP( EmbeddingOfEqualizerWithGivenEqualizer,
@@ -102,7 +102,7 @@ AddDerivationToCAP( Coequalizer,
     return Range( D[1] );
     
 end : Description := "Coequalizer using Range",
-      CategoryFilter := IsThinCategory );
+      CategoryFilter := cat -> HasIsThinCategory( cat ) and IsThinCategory( cat ) and not ( IsBound( cat!.supports_empty_limits ) and cat!.supports_empty_limits = true ) );
 
 ##
 AddDerivationToCAP( ProjectionOntoCoequalizerWithGivenCoequalizer,


### PR DESCRIPTION
Those derivations are only valid if the list of morphisms is non-empty.